### PR TITLE
make dovecot mysql backend optional (enabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ it must be concatenated after the certificate in the same file.
 * **postfix_dovecot_mysql_password** - the password to the user that has permission to query the database on the SQL database server used for authentication.
 
 #### Optional Variables
+* **sql** - [true/false], default is true, disable mysql backend
 * **postfix_dovecot_mysql_host** - the FQDN or IP address to the MySQL server for authentication. This defaults to `127.0.0.1`.
 * **postfix_dovecot_mysql_db_name** - the database name on the MySQL server used for authentication. This defaults to `servermail`.
 * **postfix_dovecot_mysql_user** - the user that has permission to query the database on the MySQL server used for authentication. This defaults to `usermail`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ dovecot_ssl: 'required'
 dovecot_listen:
 - '*'
 - '::'
+# Sql enable by default but can be disabled
+sql: true
 postfix_dovecot_mysql_password_scheme: 'SHA512-CRYPT'
 postfix_dovecot_mysql_host: '127.0.0.1'
 postfix_dovecot_mysql_db_name: 'servermail'

--- a/tasks/dovecot.yml
+++ b/tasks/dovecot.yml
@@ -5,6 +5,13 @@
     state: present
   notify: restart dovecot
 
+- name: DOVECOT | install mysql driver
+  apt:
+    pkg: dovecot-ldap
+    state: present
+  when: sql | bool
+  notify: restart dovecot
+
 - name: DOVECOT | ensure Dovecot is started and runs at startup
   service:
     name: dovecot
@@ -81,6 +88,7 @@
     owner: vmail
     group: dovecot
     mode: 0440
+  when: sql | bool
   notify: restart dovecot
 
 - name: DOVECOT | configure (10-master.conf)
@@ -108,4 +116,5 @@
     owner: vmail
     group: dovecot
     mode: 0440
+  when: sql | bool
   notify: restart dovecot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,4 +8,5 @@
 - include: dovecot.yml
 - include: postfix.yml
 - include: sql.yml
+  when: sql
 - include: postgrey.yml

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -36,6 +36,7 @@
     owner: postfix
     group: root
     mode: 0660
+  when: sql | bool
   notify: restart postfix
 
 - name: POSTFIX | configure (mysql-virtual-mailbox-domains.cf)
@@ -45,6 +46,7 @@
     owner: postfix
     group: root
     mode: 0660
+  when: sql | bool
   notify: restart postfix
 
 - name: POSTFIX | configure (mysql-virtual-mailbox-maps.cf)
@@ -54,6 +56,7 @@
     owner: postfix
     group: root
     mode: 0660
+  when: sql | bool
   notify: restart postfix
 
 - name: POSTFIX | configure (helo_access)

--- a/templates/etc/dovecot/conf.d/10-auth.conf.j2
+++ b/templates/etc/dovecot/conf.d/10-auth.conf.j2
@@ -116,8 +116,10 @@ auth_mechanisms = {{ dovecot_auth_mechanisms | join(' ') }}
 # own them. For single-UID configuration use "static" userdb.
 #
 # <doc/wiki/UserDatabase.txt>
-
+{% if sql %}
 !include auth-sql.conf.ext
+{% endif %}
+
 
 #!include auth-deny.conf.ext
 #!include auth-master.conf.ext

--- a/templates/etc/dovecot/conf.d/10-master.conf.j2
+++ b/templates/etc/dovecot/conf.d/10-master.conf.j2
@@ -94,11 +94,13 @@ service auth {
   # To give the caller full permissions to lookup all users, set the mode to
   # something else than 0666 and Dovecot lets the kernel enforce the
   # permissions (e.g. 0777 allows everyone full permissions).
+  {% if sql %}
   unix_listener auth-userdb {
     mode = 0600
     user = vmail
     #group = 
   }
+{% endif %}
 
   # Postfix smtp-auth
   unix_listener /var/spool/postfix/private/auth {

--- a/templates/etc/postfix/main.cf.j2
+++ b/templates/etc/postfix/main.cf.j2
@@ -50,9 +50,11 @@ smtpd_helo_restrictions = {{ postfix_smtpd_helo_restrictions | join(', ') }}
 smtpd_sender_restrictions = {{ postfix_smtpd_sender_restrictions | join(', ') }}
 
 virtual_transport = lmtp:unix:private/dovecot-lmtp
+{% if sql %}
 virtual_mailbox_domains = mysql:/etc/postfix/mysql-virtual-mailbox-domains.cf
 virtual_mailbox_maps = mysql:/etc/postfix/mysql-virtual-mailbox-maps.cf
 virtual_alias_maps = mysql:/etc/postfix/mysql-virtual-alias-maps.cf
+{% endif %}
 
 address_verify_negative_refresh_time = 60s
 address_verify_sender_ttl = 15686s

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,7 +4,6 @@ pkg_dovecot:
   - dovecot-imapd
   - dovecot-pop3d
   - dovecot-lmtpd
-  - dovecot-mysql
 
 pkg_postfix:
   - postfix


### PR DESCRIPTION
As dovecot can be use with other backend (local account, ldap, ... )